### PR TITLE
Add initial routing setup with GoRouter and home screen

### DIFF
--- a/lib/core/router/app_router.dart
+++ b/lib/core/router/app_router.dart
@@ -1,0 +1,33 @@
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+
+import '../../features/home/home_screen.dart';
+import 'routes.dart';
+
+class AppRouter{
+  static GoRouter router = GoRouter(
+  routes: <RouteBase>[
+    GoRoute(
+      path: Routes.home,
+      builder: (BuildContext context, GoRouterState state) {
+        return const HomeScreen();
+
+      },
+      routes: <RouteBase>[
+        GoRoute(
+          path: 'details',
+          parentNavigatorKey: GlobalKey<NavigatorState>(),
+          name: 'details',
+
+   
+          
+          builder: (BuildContext context, GoRouterState state) {
+            
+            return const Scaffold();
+          },
+        ),
+      ],
+    ),
+  ],
+);
+}

--- a/lib/core/router/routes.dart
+++ b/lib/core/router/routes.dart
@@ -1,0 +1,6 @@
+class Routes{
+
+  static const String home = '/';
+
+  static const String details = '/details';
+}

--- a/lib/features/home/home_screen.dart
+++ b/lib/features/home/home_screen.dart
@@ -1,0 +1,10 @@
+import 'package:flutter/material.dart';
+
+class HomeScreen extends StatelessWidget {
+  const HomeScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const Placeholder();
+  }
+}

--- a/lib/news_app.dart
+++ b/lib/news_app.dart
@@ -1,0 +1,17 @@
+import 'package:flutter/material.dart';
+
+import 'core/router/app_router.dart';
+
+
+
+class NewsApp extends StatelessWidget {
+  const NewsApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp.router(
+      routerConfig: AppRouter.router,
+      // home: Placeholder(),
+    );
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -320,6 +320,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.2"
+  go_router:
+    dependency: "direct main"
+    description:
+      name: go_router
+      sha256: ddc16d34b0d74cb313986918c0f0885a7ba2fc24d8fb8419de75f0015144ccfe
+      url: "https://pub.dev"
+    source: hosted
+    version: "14.2.3"
   graphs:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,6 +14,7 @@ dependencies:
   flutter_screenutil: ^5.9.3
   freezed: ^2.5.2
   freezed_annotation: ^2.4.4
+  go_router: ^14.2.3
   intl: ^0.19.0
   json_annotation: ^4.9.0
   provider: ^6.1.2


### PR DESCRIPTION
This commit introduces the foundational routing structure for the application using the GoRouter package. It includes the creation of the AppRouter class, which defines the routing configuration, and the Routes class for managing route paths. Additionally, a basic HomeScreen widget has been added to serve as the initial landing page. The NewsApp class, which serves as the main entry point for the application, has been updated to utilize the routing configuration. This setup lays the groundwork for further development of navigation and feature integration within the app. Dependencies for GoRouter have also been added to the pubspec.yaml and reflected in the pubspec.lock files.